### PR TITLE
Adding auto merge from 'dev' branch to 'gh-pages'

### DIFF
--- a/.github/workflows/merge-branch.yml
+++ b/.github/workflows/merge-branch.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - "dev"
+jobs:
+  merge-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: everlytic/branch-merge@1.1.0
+        with:
+          github_token: ${{ github.token }}
+          source_ref: 'dev'
+          target_branch: 'gh-pages'
+          commit_message_template: '[Automated] Merged {source_ref} into {target_branch}'

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,3 +1,4 @@
+name: Publish
 on:
   push:
     branches:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - "dev"
 jobs:
-  merge-branch:
+  publish-dev:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,4 +12,4 @@ jobs:
           github_token: ${{ github.token }}
           source_ref: 'dev'
           target_branch: 'gh-pages'
-          commit_message_template: '[Automated] Merged {source_ref} into {target_branch}'
+          commit_message_template: '[Automated] Merge {source_ref} into {target_branch}'


### PR DESCRIPTION
Related discussion: https://github.com/CookieMonsterTeam/CookieMonster/discussions/846

Adds a workflow that calls [this GitHub action](https://github.com/marketplace/actions/branch-merge) whenever a push is sent to the `dev` branch (i.e. when a PR is completed for `dev`). The GitHub action merges `dev` to `gh-pages`.

Here are a few examples of automated commits created by the workflow, in my fork of the repo.
1. Merge of all pending changes from `dev` to `gh-pages`, right after I created the workflow https://github.com/tsr488/CookieMonster/commit/0dd9048b03ff1b3d3ec2875af42d65aad4d97802 
2. Merge of dependabot changes after I approved a dependabot PR https://github.com/tsr488/CookieMonster/commit/437c2c47463155fbb3533c99fa01e25a427c926d